### PR TITLE
Fix Bugs - Vuex store issues

### DIFF
--- a/components/CartProductListItem/CartProductListItem.vue
+++ b/components/CartProductListItem/CartProductListItem.vue
@@ -167,9 +167,6 @@
 import firebase from 'firebase/app'
 import 'firebase/auth'
 import 'firebase/firestore'
-import { createNamespacedHelpers } from 'vuex'
-
-const { mapActions } = createNamespacedHelpers('cart')
 
 export default {
   data() {

--- a/components/Checkout/Checkout.vue
+++ b/components/Checkout/Checkout.vue
@@ -45,7 +45,6 @@
 
 <script>
 import { Card } from 'vue-stripe-elements-plus'
-import { createNamespacedHelpers } from 'vuex'
 
 const STRIPE_URL = process.env.STRIPE_URL
 
@@ -64,8 +63,6 @@ export default {
     },
   },
   methods: {
-    ...mapActions(['clearCheckout', 'pay', 'setIsStripeCardCompleted']),
-
     async beforePay() {
       await this.pay({
         url: STRIPE_URL,


### PR DESCRIPTION
This issue rise when Mus made some changes to the Cart functionality. Unused vuex store methods are not deleted. So, there is an error which is the list of the products was not displayed when the user tries to navigate to the cart pages.

What I do to fix these bugs:-
- Remove `import { createNamespacedHelpers } from 'vuex'` from CartProductListItem.vue
- Remove `const { mapActions } = createNamespacedHelpers('cart')` from CartProductListItem.vue
- Remove `import { createNamespacedHelpers } from 'vuex'` from Checkout.vue
- Remove `...mapActions(['clearCheckout', 'pay', 'setIsStripeCardCompleted']),` from Checkout.vue